### PR TITLE
NTR - Fix missing field in migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/store-plugin",
     "description": "StorePlugin Example",
-    "version": "v1.0.0",
+    "version": "v1.0.1",
     "license": "MIT",
     "authors": [
         {

--- a/src/Migration/Migration1567588156AddMissingFieldToStorePluginsTable.php
+++ b/src/Migration/Migration1567588156AddMissingFieldToStorePluginsTable.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Swag\StorePlugin\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1567588156AddMissingFieldToStorePluginsTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1567588156;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeQuery(
+            'ALTER TABLE store_plugins ADD buy_link VARCHAR(255) NULL AFTER title'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
Fixes #1.

This missing field caused an error in `\Swag\StorePlugin\Controller\StorePluginController::installDemoData`.