### PR TITLE
Update Migration1567588155StorePlugins.php

### DIFF
--- a/src/Migration/Migration1567588155StorePlugins.php
+++ b/src/Migration/Migration1567588155StorePlugins.php
@@ -14,7 +14,7 @@ class Migration1567588155StorePlugins extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $connection->executeQuery(
+        $connection->executeUpdate(
             'CREATE TABLE IF NOT EXISTS `store_plugins`
             (
                 id BINARY(16) NOT NULL,


### PR DESCRIPTION
I try to install this boilerplate but got this error:

Migration: "Swag\StorePlugin\Migration\Migration1567588155StorePlugins" failed: "Write operations are not supported when using executeQuery. Query: CREATE TABLE IF NOT EXISTS store_plugins

(
id BINARY(16) NOT NULL,
title VARCHAR(100) NULL,
cover VARCHAR(255) NULL,
created_at DATETIME(3) NOT NULL,
updated_at DATETIME(3) NULL,
PRIMARY KEY (id)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"

Problem is the function executeQuery() in the migration files. Here i changed the functions to "executeUpdate" and it works fine.